### PR TITLE
add rdkit as a pypi dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "seaborn",
     "jenkspy",
     "datamol",
+    "rdkit",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Changelogs

- Add rdkit as a pypi dep. Now possible after the rdkit conda package fix at https://github.com/conda-forge/rdkit-feedstock/pull/143

---

_Checklist:_

- [ ] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._
- [ ] _Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._
- [ ] _Update the API documentation if a new function is added, or an existing one is deleted._
- [x] _Write concise and explanatory changelogs above._
- [x] _If possible, assign one of the following labels to the PR: `feature`, `fix` or `test` (or ask a maintainer to do it for you)._

---

_discussion related to that PR_
