### PR TITLE
Added a Scikit-learn like `train_test_split` method

### DIFF
--- a/docs/api/plot.md
+++ b/docs/api/plot.md
@@ -1,3 +1,5 @@
 # `splito.plot`
 
 ::: splito.plot
+    options:
+        filters: ["!^_"]

--- a/docs/api/simpd.md
+++ b/docs/api/simpd.md
@@ -1,11 +1,15 @@
 # `splito.simpd`
 
 ::: splito.simpd.SIMPDSplitter
-
+    options:
+        filters: ["!^_"]
 ---
 
 ::: splito.simpd.run_SIMPD
-
+    options:
+        filters: ["!^_"]
 ---
 
 ::: splito.simpd.DEFAULT_SIMPD_DESCRIPTORS
+    options:
+        filters: ["!^_"]

--- a/docs/api/splito.md
+++ b/docs/api/splito.md
@@ -1,3 +1,5 @@
 # `splito`
 
 ::: splito
+    options:
+        filters: ["!^_"]

--- a/docs/api/splito.md
+++ b/docs/api/splito.md
@@ -1,5 +1,15 @@
 # `splito`
 
+## Basic usage
+
 ::: splito
     options:
-        filters: ["!^_"]
+        filters: ["train_test_split"]
+
+---
+
+## Advanced usage 
+
+::: splito
+    options:
+        filters: ["!^_", "!train_test_split"]

--- a/splito/__init__.py
+++ b/splito/__init__.py
@@ -6,7 +6,7 @@ from ._molecular_weight import MolecularWeightSplit
 from ._mood_split import MOODSplitter
 from ._perimeter_split import PerimeterSplit
 from ._scaffold_split import ScaffoldSplit
-from ._split import train_test_split
+from ._split import train_test_split, train_test_split_indices
 
 __all__ = [
     "MOODSplitter",
@@ -18,4 +18,5 @@ __all__ = [
     "MolecularWeightSplit",
     "MolecularMinMaxSplit",
     "train_test_split",
+    "train_test_split_indices",
 ]

--- a/splito/__init__.py
+++ b/splito/__init__.py
@@ -1,12 +1,12 @@
-from ._mood_split import MOODSplitter
+from ._distribution_split import StratifiedDistributionSplit
 from ._kmeans_split import KMeansSplit
-from ._perimeter_split import PerimeterSplit
 from ._max_dissimilarity_split import MaxDissimilaritySplit
-from ._scaffold_split import ScaffoldSplit
 from ._min_max_split import MolecularMinMaxSplit
 from ._molecular_weight import MolecularWeightSplit
-from ._distribution_split import StratifiedDistributionSplit
-
+from ._mood_split import MOODSplitter
+from ._perimeter_split import PerimeterSplit
+from ._scaffold_split import ScaffoldSplit
+from ._split import train_test_split
 
 __all__ = [
     "MOODSplitter",
@@ -17,4 +17,5 @@ __all__ = [
     "StratifiedDistributionSplit",
     "MolecularWeightSplit",
     "MolecularMinMaxSplit",
+    "train_test_split",
 ]

--- a/splito/_split.py
+++ b/splito/_split.py
@@ -40,6 +40,41 @@ def train_test_split(
 
     Inspired by sklearn.model_selection.train_test_split, this function is meant as a convenience function
     that provides a less verbose way of using the different splitters.
+
+    **Examples**:
+
+    Let's first create a toy dataset
+
+    ```python
+    import datamol as dm
+    import numpy as np
+
+    data = dm.data.freesolv()
+    smiles = data["smiles"].values
+    X = np.array([dm.to_fp(dm.to_mol(smi)) for smi in smiles])
+    y = data["expt"].values
+    ```
+
+    Now we can split our data.
+
+    ```python
+    X_train, X_test, y_train, y_test = train_test_split(X, y, method="random")
+    ```
+
+    More parameters
+    ```python
+    X_train, X_test, y_train, y_test = train_test_split(X, y, method="random", test_size=0.1, random_state=42)
+    ```
+
+    Scaffold split (note that you need to specify `smiles`):
+    ```python
+    X_train, X_test, y_train, y_test = train_test_split(X, y, smiles=smiles, method="scaffold")
+    ```
+
+    Distance-based split:
+    ```python
+    X_train, X_test, y_train, y_test = train_test_split(X, y, method="kmeans")
+    ```
     """
 
     X = np.array(X)

--- a/splito/_split.py
+++ b/splito/_split.py
@@ -1,0 +1,66 @@
+from enum import Enum, unique
+from typing import Optional, Sequence, Union
+
+import datamol as dm
+import numpy as np
+from sklearn.model_selection import ShuffleSplit
+
+from ._distribution_split import StratifiedDistributionSplit
+from ._kmeans_split import KMeansSplit
+from ._max_dissimilarity_split import MaxDissimilaritySplit
+from ._min_max_split import MolecularMinMaxSplit
+from ._molecular_weight import MolecularWeightSplit
+from ._perimeter_split import PerimeterSplit
+from ._scaffold_split import ScaffoldSplit
+
+
+@unique
+class SimpleSplittingMethod(Enum):
+    RANDOM = ShuffleSplit
+    KMEANS = KMeansSplit
+    PERIMETER = PerimeterSplit
+    MAX_DISSIMILARITY = MaxDissimilaritySplit
+    SCAFFOLD = ScaffoldSplit
+    STRATIFIED_DISTRIBUTION = StratifiedDistributionSplit
+    MOLECULAR_WEIGHT = MolecularWeightSplit
+    MIN_MAX_DIVERSITY_SPLIT = MolecularMinMaxSplit
+
+
+def train_test_split(
+    X: np.ndarray,
+    y: np.ndarray,
+    molecules: Optional[Sequence[Union[str, dm.Mol]]] = None,
+    method: Union[str, SimpleSplittingMethod] = "random",
+    test_size: float = 0.2,
+    seed: int = None,
+    n_jobs: Optional[int] = None,
+) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Splits a set of molecules into a train and test set.
+
+    Inspired by sklearn.model_selection.train_test_split, this function is meant as a convenience function
+    that provides a less verbose way of using the different splitters.
+    """
+
+    X = np.array(X)
+    y = np.array(y)
+
+    method = SimpleSplittingMethod[method.upper()] if isinstance(method, str) else method
+
+    splitter_kwargs = {"test_size": test_size, "random_state": seed}
+    if method in [
+        SimpleSplittingMethod.MOLECULAR_WEIGHT,
+        SimpleSplittingMethod.MIN_MAX_DIVERSITY_SPLIT,
+        SimpleSplittingMethod.SCAFFOLD,
+    ]:
+        if molecules is None:
+            raise ValueError(f"{method.name} requires a list of molecules to be provided.")
+        if isinstance(molecules[0], dm.Mol):
+            molecules = dm.utils.parallelized(dm.to_smiles, molecules, n_jobs=n_jobs)
+        splitter_kwargs["smiles"] = molecules
+
+    splitter_cls = method.value
+    splitter = splitter_cls(**splitter_kwargs)
+
+    train_indices, test_indices = next(splitter.split(X, y))
+    return X[train_indices], X[test_indices], y[train_indices], y[test_indices]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,47 @@
-import pytest
-
 import datamol as dm
+import numpy as np
+import pytest
 
 
 @pytest.fixture(scope="module")
-def test_data():
-    return dm.data.freesolv()[:100]
+def test_dataset():
+    data = dm.data.freesolv()
+    data["mol"] = [dm.to_mol(smi) for smi in data["smiles"]]
+    data = data.dropna()
+    return data
+
+
+@pytest.fixture(scope="module")
+def test_dataset_smiles(test_dataset):
+    return test_dataset["smiles"].values
+
+
+@pytest.fixture(scope="module")
+def test_dataset_targets(test_dataset):
+    return test_dataset["expt"].values
+
+
+@pytest.fixture(scope="module")
+def test_dataset_features(test_dataset):
+    return np.array([dm.to_fp(mol) for mol in test_dataset["mol"].values])
+
+
+@pytest.fixture(scope="module")
+def test_deployment_set():
+    data = dm.data.solubility()
+    data["mol"] = [dm.to_mol(smi) for smi in data["smiles"]]
+    data = data.dropna()
+    return data
+
+
+@pytest.fixture(scope="module")
+def test_deployment_smiles(test_deployment_set):
+    return test_deployment_set["smiles"].values
+
+
+@pytest.fixture(scope="module")
+def test_deployment_features(test_deployment_set):
+    return np.array([dm.to_fp(mol) for mol in test_deployment_set["mol"].values])
 
 
 @pytest.fixture(scope="module")
@@ -20,13 +56,3 @@ def manual_smiles():
         "CN1C=NC2=C1C(=O)NC(=O)N2C",
         "CN1C=NC2=C1C(=O)N(C(=O)N2C)C",
     ]
-
-
-@pytest.fixture(scope="module")
-def dataset_smiles(test_data):
-    return test_data["smiles"].values
-
-
-@pytest.fixture(scope="module")
-def dataset_targets(test_data):
-    return test_data["expt"].values

--- a/tests/test_distribution_split.py
+++ b/tests/test_distribution_split.py
@@ -5,11 +5,11 @@ from splito._distribution_split import Clustering1D
 
 
 @pytest.mark.parametrize("algorithm", list(Clustering1D))
-def test_splits_stratified_distribution(dataset_smiles, dataset_targets, algorithm):
+def test_splits_stratified_distribution(test_dataset_smiles, test_dataset_targets, algorithm):
     splitter = StratifiedDistributionSplit(algorithm=algorithm, n_splits=2)
 
-    for train_ind, test_ind in splitter.split(dataset_smiles, y=dataset_targets):
-        assert len(train_ind) + len(test_ind) == len(dataset_targets)
+    for train_ind, test_ind in splitter.split(test_dataset_smiles, y=test_dataset_targets):
+        assert len(train_ind) + len(test_ind) == len(test_dataset_targets)
         assert len(set(train_ind).intersection(set(test_ind))) == 0
         assert len(train_ind) > 0 and len(test_ind) > 0
 

--- a/tests/test_kmeans_split.py
+++ b/tests/test_kmeans_split.py
@@ -3,11 +3,11 @@ import numpy as np
 from splito import KMeansSplit
 
 
-def test_splits_kmeans_default_feats(dataset_smiles):
+def test_splits_kmeans_default_feats(test_dataset_smiles):
     splitter = KMeansSplit(n_splits=2)
 
-    for train_ind, test_ind in splitter.split(dataset_smiles):
-        assert len(train_ind) + len(test_ind) == len(dataset_smiles)
+    for train_ind, test_ind in splitter.split(test_dataset_smiles):
+        assert len(train_ind) + len(test_ind) == len(test_dataset_smiles)
         assert len(set(train_ind).intersection(set(test_ind))) == 0
         assert len(train_ind) > 0 and len(test_ind) > 0
         assert splitter._cluster_metric == "jaccard"

--- a/tests/test_max_dissimilarity_split.py
+++ b/tests/test_max_dissimilarity_split.py
@@ -3,11 +3,11 @@ import numpy as np
 from splito import MaxDissimilaritySplit
 
 
-def test_splits_max_dissimilar_default_feats(dataset_smiles):
+def test_splits_max_dissimilar_default_feats(test_dataset_smiles):
     splitter = MaxDissimilaritySplit(n_splits=2)
 
-    for train_ind, test_ind in splitter.split(dataset_smiles):
-        assert len(train_ind) + len(test_ind) == len(dataset_smiles)
+    for train_ind, test_ind in splitter.split(test_dataset_smiles):
+        assert len(train_ind) + len(test_ind) == len(test_dataset_smiles)
         assert len(set(train_ind).intersection(set(test_ind))) == 0
         assert len(train_ind) > 0 and len(test_ind) > 0
 

--- a/tests/test_min_max_split.py
+++ b/tests/test_min_max_split.py
@@ -1,10 +1,10 @@
 from splito import MolecularMinMaxSplit
 
 
-def test_splits_min_max(dataset_smiles):
+def test_splits_min_max(test_dataset_smiles):
     splitter = MolecularMinMaxSplit(n_splits=2)
 
-    for train_ind, test_ind in splitter.split(dataset_smiles):
-        assert len(train_ind) + len(test_ind) == len(dataset_smiles)
+    for train_ind, test_ind in splitter.split(test_dataset_smiles):
+        assert len(train_ind) + len(test_ind) == len(test_dataset_smiles)
         assert len(set(train_ind).intersection(set(test_ind))) == 0
         assert len(train_ind) > 0 and len(test_ind) > 0

--- a/tests/test_mood_split.py
+++ b/tests/test_mood_split.py
@@ -1,45 +1,35 @@
-import datamol as dm
-import numpy as np
 from sklearn.model_selection import ShuffleSplit
 
 from splito import (
-    MOODSplitter,
-    ScaffoldSplit,
-    PerimeterSplit,
     MaxDissimilaritySplit,
-    MolecularWeightSplit,
-    StratifiedDistributionSplit,
     MolecularMinMaxSplit,
+    MolecularWeightSplit,
+    MOODSplitter,
+    PerimeterSplit,
+    ScaffoldSplit,
+    StratifiedDistributionSplit,
 )
 
 
-def test_mood_split():
-    dataset_mols = dm.data.freesolv(as_df=False)
-    dataset_smiles = [dm.to_smiles(mol) for mol in dataset_mols if mol is not None]
-    dataset_targets = dm.data.freesolv()["expt"].values
-
-    deployment_mols = dm.data.solubility(as_df=False)
-    deployment_smiles = [dm.to_smiles(mol) for mol in deployment_mols if mol is not None]
-
-    feats_dataset = np.array([dm.to_fp(mol) for mol in dataset_smiles])
-    feats_deployment = np.array([dm.to_fp(mol) for mol in deployment_smiles])
-
+def test_mood_split(
+    test_dataset_smiles, test_dataset_features, test_dataset_targets, test_deployment_features
+):
     splitters = {
         "random": ShuffleSplit(n_splits=1),
-        "scaffold": ScaffoldSplit(dataset_smiles, n_splits=1),
+        "scaffold": ScaffoldSplit(test_dataset_smiles, n_splits=1),
         "perimeter": PerimeterSplit(metric="jaccard", n_clusters=5, n_splits=1),
         "max_dissimilarity": MaxDissimilaritySplit(metric="jaccard", n_clusters=5, n_splits=1),
-        "min_max": MolecularMinMaxSplit(smiles=dataset_smiles, n_splits=1),
-        "molecular_weight": MolecularWeightSplit(smiles=dataset_smiles, n_splits=1),
+        "min_max": MolecularMinMaxSplit(smiles=test_dataset_smiles, n_splits=1),
+        "molecular_weight": MolecularWeightSplit(smiles=test_dataset_smiles, n_splits=1),
         "stratified_distribution": StratifiedDistributionSplit(n_clusters=5, n_splits=1),
     }
 
     splitter = MOODSplitter(splitters, metric="jaccard")
-    splitter.fit(X=feats_dataset, X_deployment=feats_deployment, y=dataset_targets)
+    splitter.fit(X=test_dataset_features, X_deployment=test_deployment_features, y=test_dataset_targets)
 
-    for train_ind, test_ind in splitter.split(feats_dataset, y=dataset_targets):
-        train = feats_dataset[train_ind]
-        test = feats_dataset[test_ind]
+    for train_ind, test_ind in splitter.split(test_dataset_features, y=test_dataset_targets):
+        train = test_dataset_features[train_ind]
+        test = test_dataset_features[test_ind]
 
         assert len(train) > 0 and len(test) > 0
-        assert len(train) + len(test) == len(feats_dataset)
+        assert len(train) + len(test) == len(test_dataset_features)

--- a/tests/test_mw_split.py
+++ b/tests/test_mw_split.py
@@ -1,20 +1,25 @@
-import pytest
 import datamol as dm
+import pytest
+
 from splito import MolecularWeightSplit
 
 
 @pytest.mark.parametrize("generalize_to_larger", [True, False])
-def test_splits_molecular_weight(dataset_smiles, generalize_to_larger):
+def test_splits_molecular_weight(test_dataset_smiles, generalize_to_larger):
     splitter = MolecularWeightSplit(generalize_to_larger=generalize_to_larger, n_splits=2)
 
-    for train_ind, test_ind in splitter.split(dataset_smiles):
-        assert len(train_ind) + len(test_ind) == len(dataset_smiles)
+    for train_ind, test_ind in splitter.split(test_dataset_smiles):
+        assert len(train_ind) + len(test_ind) == len(test_dataset_smiles)
         assert len(set(train_ind).intersection(set(test_ind))) == 0
         assert len(train_ind) > len(test_ind)
         assert len(train_ind) > 0 and len(test_ind) > 0
 
-        train_mws = [dm.descriptors.mw(dm.to_mol(smi)) for smi in dataset_smiles[train_ind]]
+        train_mws = [dm.descriptors.mw(dm.to_mol(smi)) for smi in test_dataset_smiles[train_ind]]
         if generalize_to_larger:
-            assert all(dm.descriptors.mw(dm.to_mol(smi)) > max(train_mws) for smi in dataset_smiles[test_ind])
+            assert all(
+                dm.descriptors.mw(dm.to_mol(smi)) >= max(train_mws) for smi in test_dataset_smiles[test_ind]
+            )
         else:
-            assert all(dm.descriptors.mw(dm.to_mol(smi)) < min(train_mws) for smi in dataset_smiles[test_ind])
+            assert all(
+                dm.descriptors.mw(dm.to_mol(smi)) <= min(train_mws) for smi in test_dataset_smiles[test_ind]
+            )

--- a/tests/test_perimeter_split.py
+++ b/tests/test_perimeter_split.py
@@ -3,11 +3,11 @@ import numpy as np
 from splito import PerimeterSplit
 
 
-def test_splits_perimeter(dataset_smiles):
+def test_splits_perimeter(test_dataset_smiles):
     splitter = PerimeterSplit(n_splits=2)
 
-    for train_ind, test_ind in splitter.split(dataset_smiles):
-        assert len(train_ind) + len(test_ind) == len(dataset_smiles)
+    for train_ind, test_ind in splitter.split(test_dataset_smiles):
+        assert len(train_ind) + len(test_ind) == len(test_dataset_smiles)
         assert len(set(train_ind).intersection(set(test_ind))) == 0
         assert len(train_ind) > 0 and len(test_ind) > 0
         assert splitter._metric == "jaccard"

--- a/tests/test_scaffold_split.py
+++ b/tests/test_scaffold_split.py
@@ -1,4 +1,5 @@
 import pytest
+
 from splito import ScaffoldSplit
 from splito._scaffold_split import get_scaffold
 
@@ -14,13 +15,13 @@ def test_get_scaffold_generic(manual_smiles):
 
 
 @pytest.mark.parametrize("make_generic", [True, False])
-def test_splits_scaffold(dataset_smiles, make_generic):
-    splitter = ScaffoldSplit(dataset_smiles, n_splits=2, make_generic=make_generic)
-    for train_ind, test_ind in splitter.split(dataset_smiles):
-        assert len(train_ind) + len(test_ind) == len(dataset_smiles)
+def test_splits_scaffold(test_dataset_smiles, make_generic):
+    splitter = ScaffoldSplit(test_dataset_smiles, n_splits=2, make_generic=make_generic)
+    for train_ind, test_ind in splitter.split(test_dataset_smiles):
+        assert len(train_ind) + len(test_ind) == len(test_dataset_smiles)
         assert len(set(train_ind).intersection(set(test_ind))) == 0
         assert len(train_ind) > 0 and len(test_ind) > 0
 
-        train_scfs = set([get_scaffold(dataset_smiles[i], make_generic=make_generic) for i in train_ind])
-        test_scfs = [get_scaffold(dataset_smiles[i], make_generic=make_generic) for i in test_ind]
+        train_scfs = set([get_scaffold(test_dataset_smiles[i], make_generic=make_generic) for i in train_ind])
+        test_scfs = [get_scaffold(test_dataset_smiles[i], make_generic=make_generic) for i in test_ind]
         assert not any(test_scf in train_scfs for test_scf in test_scfs)

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -6,7 +6,13 @@ from splito._split import SimpleSplittingMethod
 
 
 @pytest.mark.parametrize("method", list(SimpleSplittingMethod))
-def test_train_test_split(method, test_dataset_smiles, test_dataset_targets, test_dataset_features):
+@pytest.mark.parametrize("as_string", [True, False])
+def test_train_test_split(
+    method, as_string, test_dataset_smiles, test_dataset_targets, test_dataset_features
+):
+    if as_string:
+        method = method.name.lower()
+
     X_train, X_test, y_train, y_test = train_test_split(
         X=test_dataset_features, y=test_dataset_targets, method=method, molecules=test_dataset_smiles
     )

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -1,0 +1,20 @@
+import numpy as np
+import pytest
+
+from splito import train_test_split
+from splito._split import SimpleSplittingMethod
+
+
+@pytest.mark.parametrize("method", list(SimpleSplittingMethod))
+def test_train_test_split(method, test_dataset_smiles, test_dataset_targets, test_dataset_features):
+    X_train, X_test, y_train, y_test = train_test_split(
+        X=test_dataset_features, y=test_dataset_targets, method=method, molecules=test_dataset_smiles
+    )
+    assert isinstance(X_train, np.ndarray)
+    assert isinstance(y_train, np.ndarray)
+    assert isinstance(X_test, np.ndarray)
+    assert isinstance(y_test, np.ndarray)
+    assert len(X_train) > 0 and len(X_test) > 0
+    assert len(X_train) + len(X_test) == len(test_dataset_features)
+    assert len(y_train) == len(X_train)
+    assert len(y_test) == len(X_test)


### PR DESCRIPTION
## Changelogs

- Closes #8 by adding a general `train_test_split` method

---

_Checklist:_

- [X] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._
- [X] _Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._
- [x] _Update the API documentation if a new function is added, or an existing one is deleted._
- [X] _Write concise and explanatory changelogs above._
- [X] _If possible, assign one of the following labels to the PR: `feature`, `fix` or `test` (or ask a maintainer to do it for you)._

---

You can now do: 

```python
from splito import train_test_split

X_train, X_test, y_train, y_test = train_test_split(X, y, smiles=smiles, method="scaffold")
```
