### PR TITLE
update argument from nBits to fpSize to accomodate new datamol version

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -18,7 +18,7 @@ dependencies:
   - jenkspy
 
   # Chemistry
-  - datamol >=0.11.1
+  - datamol >=0.12.5
 
   # Optional: SIMPD splitter
   - pymoo >=0.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "matplotlib",
     "seaborn",
     "jenkspy",
-    "datamol",
+    "datamol>=0.12.5",
     "rdkit",
 ]
 

--- a/splito/_distance_split_base.py
+++ b/splito/_distance_split_base.py
@@ -13,7 +13,7 @@ from sklearn.utils.validation import _num_samples  # noqa W0212
 from .utils import get_kmeans_clusters
 
 # In case users provide a list of SMILES instead of features, we rely on ECFP4 and the tanimoto distance by default
-MOLECULE_DEFAULT_FEATURIZER = dict(name="ecfp", kwargs=dict(radius=2, nBits=2048))
+MOLECULE_DEFAULT_FEATURIZER = dict(name="ecfp", kwargs=dict(radius=2, fpSize=2048))
 MOLECULE_DEFAULT_DISTANCE_METRIC = "jaccard"
 
 

--- a/splito/lohi/_lo.py
+++ b/splito/lohi/_lo.py
@@ -1,9 +1,10 @@
-from rdkit import DataStructs
-import numpy as np
-from tqdm import tqdm
-import datamol as dm
 import functools
+
+import datamol as dm
+import numpy as np
 from loguru import logger
+from rdkit import DataStructs
+from tqdm import tqdm
 
 
 class LoSplitter:
@@ -78,7 +79,7 @@ class LoSplitter:
         train_nodes = np.array(range(len(smiles)))
 
         train_fps = dm.parallelized(
-            functools.partial(dm.to_fp, as_array=False, radius=2, nBits=1024),
+            functools.partial(dm.to_fp, as_array=False, radius=2, fpSize=1024),
             smiles,
             n_jobs=n_jobs,
         )

--- a/splito/lohi/_lo.py
+++ b/splito/lohi/_lo.py
@@ -1,10 +1,9 @@
-import functools
-
-import datamol as dm
-import numpy as np
-from loguru import logger
 from rdkit import DataStructs
+import numpy as np
 from tqdm import tqdm
+import datamol as dm
+import functools
+from loguru import logger
 
 
 class LoSplitter:

--- a/tests/test_lo.py
+++ b/tests/test_lo.py
@@ -26,7 +26,7 @@ def one_cluster_check(train_idx, cluster_idx, smiles, threshold, min_cluster_siz
     # Ensure there is only one similar molecule in the train
     train_smiles = smiles[train_idx]
     cluster_smiles = smiles[cluster_idx]
-    distance_matrix = dm.similarity.cdist(cluster_smiles, train_smiles, radius=2, nBits=1024)
+    distance_matrix = dm.similarity.cdist(cluster_smiles, train_smiles, radius=2, fpSize=1024)
     similarity_matrix = 1.0 - distance_matrix
     is_too_similar = similarity_matrix > threshold
     no_hits_per_mol = np.sum(is_too_similar, axis=1)


### PR DESCRIPTION
As discussed in #16, `datamol` switched from using `GetMorganFingerprintAsBitVect` to `GetMorganGenerator` in version `0.12.5`. This PR update the argument from `nBits` to `fpSize`  and set a minimum version for `datamol`.

## Changelogs
- Update default argument from `nBits` to `fpSize`.
- Fix datamol version to above 0.12.5.
---

_Checklist:_

- [x] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._
- [x] _Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._
- [x] _Update the API documentation if a new function is added, or an existing one is deleted._
- [x] _Write concise and explanatory changelogs above._
- [x] _If possible, assign one of the following labels to the PR: `feature`, `fix` or `test` (or ask a maintainer to do it for you)._

---

_discussion related to that PR_
