### PR TITLE
Remove polyfill

### DIFF
--- a/0.1.0/tutorials/MOOD_Protocol.html
+++ b/0.1.0/tutorials/MOOD_Protocol.html
@@ -1256,9 +1256,7 @@ splitter.fit(X=np.stack(dataset_feat), X_deployment=np.stack(deployment_feat))</
     
     
       <script src="../assets/javascripts/bundle.aecac24b.min.js"></script>
-      
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
+            
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.1.1/tutorials/Other_Splitters.html
+++ b/0.1.1/tutorials/Other_Splitters.html
@@ -1804,8 +1804,6 @@ Name: expt, dtype: object</pre>
     
       <script src="../assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.1.1/tutorials/utils.html
+++ b/0.1.1/tutorials/utils.html
@@ -1227,7 +1227,6 @@ import warnings</div>
     
       <script src="../assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/0.1.2/api/splito.html
+++ b/0.1.2/api/splito.html
@@ -1970,7 +1970,6 @@ we will instead use a 1D clustering of the readout.</p>
     
       <script src="../assets/javascripts/bundle.d7c377c4.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/0.1.2/tutorials/MOOD_Protocol.html
+++ b/0.1.2/tutorials/MOOD_Protocol.html
@@ -1420,9 +1420,7 @@ splitter.fit(X=np.stack(dataset_feat), X_deployment=np.stack(deployment_feat))</
     
     
       <script src="../assets/javascripts/bundle.d7c377c4.min.js"></script>
-      
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
+            
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.1.2/tutorials/MPO_Splitters.html
+++ b/0.1.2/tutorials/MPO_Splitters.html
@@ -1982,7 +1982,6 @@ data.loc[test_idx, "SIMPDSplit"] = "test"</div>
     
       <script src="../assets/javascripts/bundle.d7c377c4.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/0.1.2/tutorials/Other_Splitters.html
+++ b/0.1.2/tutorials/Other_Splitters.html
@@ -1824,7 +1824,6 @@ Name: expt, dtype: object</pre>
     
       <script src="../assets/javascripts/bundle.d7c377c4.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/0.1.2/tutorials/Structure_based_Splitters.html
+++ b/0.1.2/tutorials/Structure_based_Splitters.html
@@ -1705,7 +1705,6 @@ data.loc[test_idx, "MaxDissimilaritySplit"] = "test"</div>
     
       <script src="../assets/javascripts/bundle.d7c377c4.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/0.1.2/tutorials/The_Basics.html
+++ b/0.1.2/tutorials/The_Basics.html
@@ -1593,8 +1593,6 @@ data["scaffold"] = splitter.scaffolds</div>
     
       <script src="../assets/javascripts/bundle.d7c377c4.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.1.2/tutorials/utils.html
+++ b/0.1.2/tutorials/utils.html
@@ -1247,7 +1247,6 @@ import warnings</div>
     
       <script src="../assets/javascripts/bundle.d7c377c4.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/0.1.3/404.html
+++ b/0.1.3/404.html
@@ -660,7 +660,6 @@
     
       <script src="/datamol-io/splito/0.1.3/assets/javascripts/bundle.1e8ae164.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/0.1.3/api/plot.html
+++ b/0.1.3/api/plot.html
@@ -875,7 +875,6 @@
     
       <script src="../assets/javascripts/bundle.1e8ae164.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/0.1.3/api/simpd.html
+++ b/0.1.3/api/simpd.html
@@ -1082,7 +1082,6 @@ available at <a href="https://chemrxiv.org/engage/chemrxiv/article-details/64060
     
       <script src="../assets/javascripts/bundle.1e8ae164.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/0.1.3/api/splito.html
+++ b/0.1.3/api/splito.html
@@ -2206,7 +2206,6 @@ of the high-dimensional data cloud.</p>
     
       <script src="../assets/javascripts/bundle.1e8ae164.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/0.1.3/api/utils.html
+++ b/0.1.3/api/utils.html
@@ -1082,7 +1082,6 @@ to transform the data into a euclidean compatible space.</p>
     
       <script src="../assets/javascripts/bundle.1e8ae164.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/0.1.3/index.html
+++ b/0.1.3/index.html
@@ -840,7 +840,6 @@
     
       <script src="assets/javascripts/bundle.1e8ae164.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/0.1.3/tutorials/MOOD_Protocol.html
+++ b/0.1.3/tutorials/MOOD_Protocol.html
@@ -1458,7 +1458,6 @@ splitter.fit(X=np.stack(dataset_feat), X_deployment=np.stack(deployment_feat))</
     
       <script src="../assets/javascripts/bundle.1e8ae164.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/0.1.3/tutorials/MPO_Splitters.html
+++ b/0.1.3/tutorials/MPO_Splitters.html
@@ -2019,7 +2019,6 @@ data.loc[test_idx, "SIMPDSplit"] = "test"</div>
     
       <script src="../assets/javascripts/bundle.1e8ae164.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/0.1.3/tutorials/Other_Splitters.html
+++ b/0.1.3/tutorials/Other_Splitters.html
@@ -1861,7 +1861,6 @@ Name: expt, dtype: object</pre>
     
       <script src="../assets/javascripts/bundle.1e8ae164.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/0.1.3/tutorials/Structure_based_Splitters.html
+++ b/0.1.3/tutorials/Structure_based_Splitters.html
@@ -1742,7 +1742,6 @@ data.loc[test_idx, "MaxDissimilaritySplit"] = "test"</div>
     
       <script src="../assets/javascripts/bundle.1e8ae164.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/0.1.3/tutorials/The_Basics.html
+++ b/0.1.3/tutorials/The_Basics.html
@@ -1630,7 +1630,6 @@ data["scaffold"] = splitter.scaffolds</div>
     
       <script src="../assets/javascripts/bundle.1e8ae164.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/0.1.3/tutorials/utils.html
+++ b/0.1.3/tutorials/utils.html
@@ -1281,7 +1281,6 @@ import warnings</div>
     
       <script src="../assets/javascripts/bundle.1e8ae164.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/stable/404.html
+++ b/stable/404.html
@@ -660,7 +660,6 @@
     
       <script src="/datamol-io/splito/stable/assets/javascripts/bundle.1e8ae164.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/stable/api/plot.html
+++ b/stable/api/plot.html
@@ -875,7 +875,6 @@
     
       <script src="../assets/javascripts/bundle.1e8ae164.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/stable/api/simpd.html
+++ b/stable/api/simpd.html
@@ -1082,7 +1082,6 @@ available at <a href="https://chemrxiv.org/engage/chemrxiv/article-details/64060
     
       <script src="../assets/javascripts/bundle.1e8ae164.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/stable/api/splito.html
+++ b/stable/api/splito.html
@@ -2206,7 +2206,6 @@ of the high-dimensional data cloud.</p>
     
       <script src="../assets/javascripts/bundle.1e8ae164.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/stable/api/utils.html
+++ b/stable/api/utils.html
@@ -1082,7 +1082,6 @@ to transform the data into a euclidean compatible space.</p>
     
       <script src="../assets/javascripts/bundle.1e8ae164.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/stable/index.html
+++ b/stable/index.html
@@ -840,7 +840,6 @@
     
       <script src="assets/javascripts/bundle.1e8ae164.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/stable/tutorials/MOOD_Protocol.html
+++ b/stable/tutorials/MOOD_Protocol.html
@@ -1458,7 +1458,6 @@ splitter.fit(X=np.stack(dataset_feat), X_deployment=np.stack(deployment_feat))</
     
       <script src="../assets/javascripts/bundle.1e8ae164.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/stable/tutorials/MPO_Splitters.html
+++ b/stable/tutorials/MPO_Splitters.html
@@ -2019,7 +2019,6 @@ data.loc[test_idx, "SIMPDSplit"] = "test"</div>
     
       <script src="../assets/javascripts/bundle.1e8ae164.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/stable/tutorials/Other_Splitters.html
+++ b/stable/tutorials/Other_Splitters.html
@@ -1861,7 +1861,6 @@ Name: expt, dtype: object</pre>
     
       <script src="../assets/javascripts/bundle.1e8ae164.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/stable/tutorials/Structure_based_Splitters.html
+++ b/stable/tutorials/Structure_based_Splitters.html
@@ -1742,7 +1742,6 @@ data.loc[test_idx, "MaxDissimilaritySplit"] = "test"</div>
     
       <script src="../assets/javascripts/bundle.1e8ae164.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/stable/tutorials/The_Basics.html
+++ b/stable/tutorials/The_Basics.html
@@ -1630,7 +1630,6 @@ data["scaffold"] = splitter.scaffolds</div>
     
       <script src="../assets/javascripts/bundle.1e8ae164.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/stable/tutorials/utils.html
+++ b/stable/tutorials/utils.html
@@ -1281,7 +1281,6 @@ import warnings</div>
     
       <script src="../assets/javascripts/bundle.1e8ae164.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       


### PR DESCRIPTION
## Changelogs

- Removed the `polyfill` JS from our documentation

---

This is a hotfix needed due to a supply chain attack. See https://thehackernews.com/2024/06/over-110000-websites-affected-by.html
