### PR TITLE
No longer manually upgrade `mkdocs-jupyter` through PyPi in the CICD

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -27,8 +27,8 @@ jobs:
         with:
           environment-file: env.yml
           environment-name: my_env
-          cache-environment: false
-          cache-downloads: false
+          cache-environment: true
+          cache-downloads: true
 
       - name: Install library
         run: python -m pip install --no-deps .

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -31,11 +31,7 @@ jobs:
           cache-downloads: true
 
       - name: Install library
-        run: |
-          python -m pip install --no-deps .
-          # Note: Temporarily upgrade mkdocs-jupyter through PyPi
-          # See https://github.com/conda-forge/mkdocs-jupyter-feedstock/pull/30
-          python -m pip install mkdocs-jupyter -U
+        run: python -m pip install --no-deps .
 
       - name: Configure git
         run: |

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -27,8 +27,8 @@ jobs:
         with:
           environment-file: env.yml
           environment-name: my_env
-          cache-environment: true
-          cache-downloads: true
+          cache-environment: false
+          cache-downloads: false
 
       - name: Install library
         run: python -m pip install --no-deps .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,8 @@ jobs:
         with:
           environment-file: env.yml
           environment-name: my_env
-          cache-environment: true
-          cache-downloads: true
+          cache-environment: false
+          cache-downloads: false
           create-args: >-
             pip
             semver

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,11 +99,7 @@ jobs:
           git push origin "${{ inputs.release-version }}"
 
       - name: Install library
-        run: |
-          python -m pip install --no-deps .
-          # Note: Temporarily upgrade mkdocs-jupyter through PyPi
-          # See https://github.com/conda-forge/mkdocs-jupyter-feedstock/pull/30
-          python -m pip install mkdocs-jupyter -U
+        run: python -m pip install --no-deps .
 
       - name: Build the wheel and sdist
         run: python -m build --no-isolation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,8 @@ jobs:
         with:
           environment-file: env.yml
           environment-name: my_env
-          cache-environment: false
-          cache-downloads: false
+          cache-environment: true
+          cache-downloads: true
           create-args: >-
             pip
             semver

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,8 +37,8 @@ jobs:
         with:
           environment-file: env.yml
           environment-name: my_env
-          cache-environment: false
-          cache-downloads: false
+          cache-environment: true
+          cache-downloads: true
           create-args: >-
             python=${{ matrix.python-version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,8 +37,8 @@ jobs:
         with:
           environment-file: env.yml
           environment-name: my_env
-          cache-environment: true
-          cache-downloads: true
+          cache-environment: false
+          cache-downloads: false
           create-args: >-
             python=${{ matrix.python-version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,11 +43,7 @@ jobs:
             python=${{ matrix.python-version }}
 
       - name: Install library
-        run: |
-          python -m pip install --no-deps -e .  # -e (editable is needed for code coverage)
-          # Note: Temporarily upgrade mkdocs-jupyter through PyPi
-          # See https://github.com/conda-forge/mkdocs-jupyter-feedstock/pull/30
-          python -m pip install mkdocs-jupyter -U
+        run: python -m pip install --no-deps -e .  # -e (editable is needed for code coverage)
 
       - name: Run tests
         run: pytest

--- a/env.yml
+++ b/env.yml
@@ -40,7 +40,7 @@ dependencies:
   - mkdocs-material-extensions
   - mkdocstrings
   - mkdocstrings-python
-  - mkdocs-jupyter
+  - mkdocs-jupyter >=0.24.8
   - markdown-include
   - mdx_truly_sane_lists
   - nbconvert


### PR DESCRIPTION
## Changelogs

- No longer manually upgrade `mkdocs-jupyter` through PyPi in the CICD

---

For details, see https://github.com/conda-forge/mkdocs-jupyter-feedstock/issues/31
